### PR TITLE
【fix】ハンバーガーメニューのメニューが画面右端に表示されていたので修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
   <body data-controller="hamburger">
     <%= render "shared/header" %>
 
-    <div class="relative min-h-screen bg-main-bg">
+    <div class="relative min-h-screen bg-main-bg overflow-hidden">
       <%= yield %>
       <%= render "shared/hamburger_menu" %>
     </div>


### PR DESCRIPTION
## 概要
親要素にoverflow-hiddenを追加し、はみ出た分は表示されないように修正
- Close #92

## 実装理由
ハンバーガーメニューのメニューの分画面が広がっていたため、

## 作業内容
1. application.html.erbにある、各ページの親要素にoverflow-hiddenを設定する

## 作業結果
ハンバーガーメニューが非表示時には表示されなくなった。

## 未実施項目
issueはすべて実施

## 課題・備考
なし
