### PR TITLE
【add】メニューにカード一覧とグループ一覧へのリンクを設定

### DIFF
--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -11,7 +11,7 @@
     </div>
     <ul>
       <li class="border-b border-gray-200">
-        <%= link_to "#", class: "flex items-center justify-between px-6 py-4 text-text hover:bg-gray-100 transition" do %>
+        <%= link_to cards_path, class: "flex items-center justify-between px-6 py-4 text-text hover:bg-gray-100 transition" do %>
           <span>カード一覧</span>
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -19,7 +19,7 @@
         <% end %>
       </li>
       <li class="border-b border-gray-200">
-        <%= link_to "#", class: "flex items-center justify-between px-6 py-4 text-text hover:bg-gray-100 transition" do %>
+        <%= link_to groups_path, class: "flex items-center justify-between px-6 py-4 text-text hover:bg-gray-100 transition" do %>
           <span>グループ一覧</span>
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>


### PR DESCRIPTION
## 概要
メニューにカード一覧とグループ一覧へのリンクを設定
- Close #103 

## 実装理由
メニューにリンクが設定されていなかったため

## 作業内容
1. メニューの「カード一覧」にカード一覧ページのリンクを設定
2. メニューの「グループ一覧」にグループ一覧ページのリンクを設定

## 作業結果
メニューから、カード一覧ページとグループ一覧ページにアクセスできる

## 未実施項目
issueはすべて実施

## 課題・備考
なし
