### PR TITLE
【add】オートコンプリート以外に手動でスポット名を追加できるように入力フォームを追加

### DIFF
--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -25,13 +25,21 @@
           <!--- スポット名 -->
           <div class="mb-6">
             <%= f.label :name, t('spots.form.name'), class: "block text-sm font-medium text-text mb-2" %>
+            <%= f.text_field :name,
+                data: { autocomplete_target: "nameField" },
+                placeholder: t('spots.form.name_placeholder'),
+                class: "form-text-field" %>
+
+            <!-- オートコンプリートは補助として表示 -->
+            <div class="mt-2 text-xs text-gray-600">
+              または下から施設を検索して選択：
+            </div>
             <gmp-place-autocomplete
               id="spot-auto-input"
               data-autocomplete-target="autocomplete"
               country="jp"
-              class="form-text-field p-0">
+              class="form-text-field p-0 mt-1">
             </gmp-place-autocomplete>
-            <%= f.hidden_field :name, data: { autocomplete_target: "nameField" } %>
           </div>
 
           <!-- カテゴリ -->


### PR DESCRIPTION
## 概要
オートコンプリート以外に手動でスポット名を追加できるように入力フォームを追加
- Close #130 

## 実装理由
googlmapAPIから取得できないスポットも追加できるようにするため。

## 作業内容
1. 手動入力用のフォームを作成フォームに追加

## 作業結果
- 手動入力フォームとオートコンプリートのフォームが併存する。
- どちらを使うかユーザーが選択できる。

## 未実施項目
-issueはすべて実施。

## 課題・備考
一つのフォームで実現できるかもしれないがMVPは併存で。
