### PR TITLE
【add】spotモデルにschedule_spotモデルへの関連付けhas_manyを追加

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -25,6 +25,7 @@
 #  fk_rails_...  (category_id => categories.id)
 #
 class Spot < ApplicationRecord
+  has_many :schedule_spots, dependent: :nullify
   belongs_to :card
   belongs_to :category
 


### PR DESCRIPTION
## 概要
spotモデルにschedule_spotモデルへの関連付けhas_manyを追加
- Close #147 

## 実装理由
spotモデルにschedule_spotモデルとの関連を持たせるため。
（schedule_spotモデルを実装したissue #44 で、spotモデルへの関連付けを忘れていた）

## 作業内容
1. spotモデルに、schedule_spotへのhas_manyを追加

## 作業結果
- spotモデルに関連付けが設定される。

## 未実施項目
issueはすべて実施。

## 課題・備考
- spotが削除された場合、schedule_spotsテーブルのレコードのspot_idはnullにするため、dependent: :nullifyオプションを設定。
