### PR TITLE
【add】しおりスポット詳細ページに編集等のボタンを追加

### DIFF
--- a/app/views/groups/schedule_spots/show.html.erb
+++ b/app/views/groups/schedule_spots/show.html.erb
@@ -57,9 +57,9 @@
       </div>
 
       <div class="flex gap-3 mt-8">
-        <%= link_to "Edit", "#", class: "btn-main flex-1 text-center" %>
-        <%= link_to "Delete", "#", class: "btn-sub flex-1 text-center" %>
-        <%= link_to "Back", "#", data: {turbo_frame: "_top"}, class: "btn-sub flex-1 text-center" %>
+        <%= link_to t('cards.form.edit'), "#", class: "btn-main flex-1 text-center" %>
+        <%= link_to t('cards.form.delete'), "#", class: "btn-sub flex-1 text-center" %>
+        <%= link_to t('cards.form.back'), group_schedule_path(@group), data: {turbo_frame: "_top"}, class: "btn-sub flex-1 text-center" %>
       </div>
     </main>
   </div>

--- a/app/views/users/schedule_spots/show.html.erb
+++ b/app/views/users/schedule_spots/show.html.erb
@@ -57,9 +57,9 @@
       </div>
 
       <div class="flex gap-3 mt-8">
-        <%= link_to "Edit", "#", class: "btn-main flex-1 text-center" %>
-        <%= link_to "Delete", "#", class: "btn-sub flex-1 text-center" %>
-        <%= link_to "Back", "#", data: {turbo_frame: "_top"}, class: "btn-sub flex-1 text-center" %>
+        <%= link_to t('cards.form.edit'), "#", class: "btn-main flex-1 text-center" %>
+        <%= link_to t('cards.form.delete'), "#", class: "btn-sub flex-1 text-center" %>
+        <%= link_to t('cards.form.back'), schedule_path(@schedule), data: {turbo_frame: "_top"}, class: "btn-sub flex-1 text-center" %>
       </div>
     </main>
   </div>


### PR DESCRIPTION
## 概要
しおりスポット詳細ページに編集等のボタンを追加
- Close #50
- しおりのスポット詳細ページフォームは、issue https://github.com/koza-ken/rakuci/pull/155 で実装済み。
- 個人カードのスポット詳細ページフォームは、issue https://github.com/koza-ken/rakuci/issues/33 で実装済み。

## 実装理由
しおりやカードに追加しているスポットの詳細情報を表示するため。

## 作業内容
（ページ自体はすでに作成済み）
1. ボタンを配置し、戻るボタンのリンク先を設定。

## 作業結果
- スポット詳細ページが表示され、戻るボタンで前のページに戻ることができる。

## 未実施項目
- issueはすべて実施。

## 課題・備考
なし
