### PR TITLE
【fix】カード作成モーダルのキャンセルボタンリンクを修正

### DIFF
--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -38,14 +38,14 @@
                 placeholder: t('cards.form.memo_placeholder'),
                 class: "form-text-field resize-vertical" %>
           </div>
-          
+
           <!-- JavaScriptで動的に設定されるgroup_id -->
           <%= f.hidden_field :group_id %>
 
           <!-- ボタン -->
           <div class="flex gap-3">
             <%= f.submit t('cards.form.submit'), class: "btn-main flex-1" %>
-            <%= link_to t('cards.form.cancel'), cards_path, data: { action: "click->modal#close" }, class: "btn-sub flex-1 text-center" %>
+            <%= link_to t('cards.form.cancel'), :back, data: { action: "click->modal#close" }, class: "btn-sub flex-1 text-center" %>
           </div>
         <% end %>
       </main>


### PR DESCRIPTION
## 概要
カード作成モーダルのキャンセルボタンリンクを修正する。
- Close #165
- 作成モーダル実装時のissue #24 

## 実装理由
カード作成モーダルのキャンセルボタンのリンクが、カード一覧ページになっていたため。
（グループ用カード作成モーダルの場合はグループ詳細ページに遷移させる）

## 作業内容
1. /cards/new.html.erbのキャンセルボタンのリンク先を修正。

## 作業結果
- グループ詳細ページでカード作成モーダルをキャンセルで閉じるとグループ詳細ページを表示する。
- カード一覧ページでキャンセルを行うとカード一覧ページを表示する。

## 未実施項目
issueはすべて実施。

## 課題・備考
- 個人カード作成とグループカード作成のモーダルが共通のため、パスは「:back」で実装。
- キャンセルを押すとページ遷移によってページ上部が表示されるので、モーダルを閉じるという感覚でいうならパスの修正が必要かもしれない。
