### PR TITLE
【style】画面サイズの最大値を適用

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
     <%= render "shared/header" %>
 
     <div class="relative min-h-screen bg-main-bg overflow-hidden">
-      <%= yield %>
+      <div class="max-w-[640px] mx-auto">
+        <%= yield %>
+      </div>
       <%= render "shared/hamburger_menu" %>
       <div id="flash-container">
         <%= render "shared/flash_messages", flash: flash %>


### PR DESCRIPTION
## 概要
レスポンシブ対応実装までの間、画面サイズの最大値を適用する。
- Close #216 

## 実装理由
レスポンシブ未実装でレイアウトが崩れないようにするため。

## 作業内容
1. レイアウトテンプレートに上限を追加

## 作業結果
- パソコンで表示しても画面中央によって表示する。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
