### PR TITLE
【fix】グループしおり詳細ページの戻るボタンのリンクをグループ詳細ページへのリンクに修正

### DIFF
--- a/app/views/groups/schedules/_show.html.erb
+++ b/app/views/groups/schedules/_show.html.erb
@@ -59,6 +59,6 @@
   <%# 操作ボタン %>
   <div class="mt-8 flex gap-3">
     <%= link_to t('schedules.show.edit'), edit_group_schedule_path(group), class: "btn-main flex-1 text-center" %>
-    <%= link_to t('users.schedules.show.back'), :back, class: "btn-sub flex-1 text-center" %>
+    <%= link_to t('users.schedules.show.back'), group_path(@group), class: "btn-sub flex-1 text-center" %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
グループしおり詳細ページの戻るボタンのリンクをグループ詳細ページへのリンクに修正する。
- Close #227 

## 実装理由
グループしおり詳細ページの戻るボタンのリンクが正しく動作しないため（:backになっていた）

## 作業内容
1. ボタンのリンクをグループ詳細ページに修正する。

## 作業結果
- グループしおり詳細ページの戻るボタンを押すと、グループ詳細ページに遷移する。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
