### PR TITLE
【fix】カード詳細ページの戻るボタンのリンク先を修正

### DIFF
--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -115,8 +115,14 @@
 
     <%# 戻るボタンと削除ボタン %>
     <div class="mt-8">
-      <%= link_to cards_path, class: "btn-sub block text-center" do %>
-        <%= t("cards.form.back") %>
+      <% if @card.group_card? %>
+        <%= link_to group_path(@card.group_id), class: "btn-sub block text-center" do %>
+          <%= t("cards.form.back") %>
+        <% end %>
+      <% else %>
+        <%= link_to cards_path, class: "btn-sub block text-center" do %>
+          <%= t("cards.form.back") %>
+        <% end %>
       <% end %>
     </div>
     <div class="flex justify-center mt-18">


### PR DESCRIPTION
## 概要
カード詳細ページの戻るボタンのリンク先を修正する。
- Close #239 

## 実装理由
戻るボタンが一律でグループ詳細ページになっていたため。

## 作業内容
1. 戻るボタンのリンクを条件で分岐させる。

## 作業結果
- カード一覧からアクセスすると、カード一覧ページに遷移する。
- グループ詳細ページからアクセスすると、グループ詳細ページに遷移する。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
