### PR TITLE
【fix】ログインボタンがリロードしないと反応しないのでturbo:falseに修正

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -42,10 +42,10 @@
 
       <%# ボタングループ %>
       <div class="flex flex-col w-64">
-        <%= link_to new_user_session_path, class: "btn-main text-center mb-8" do %>
+        <%= link_to new_user_session_path, class: "btn-main text-center mb-8", data: { turbo: false } do %>
           ログイン
         <% end %>
-        <%= link_to new_user_registration_path, class: "btn-main text-center" do %>
+        <%= link_to new_user_registration_path, class: "btn-main text-center", data: { turbo: false } do %>
           新規登録
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
ログイン・新規登録ボタンをturbo:falseに修正する。
- Close #なし

## 実装理由
画面をリロードしないとボタンが反応しないため。

## 作業内容
1. ログインと新規登録ボタンをturbo:falseに修正

## 作業結果
- ページ遷移すれば反応する。

## 課題・備考
なし
