### PR TITLE
【fix】ログイン・新規登録ページのdiv閉じタグが足りていなかったのでHTML構造の見直し

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -43,22 +43,10 @@
             <% end %>
           <% end %>
         </div>
-      </div>
-<%
-=begin
-%>
-        <%# 利用規約とプライバシーポリシーへの同意 %>
-        <div class="mb-6 text-sm text-text text-center">
-          <%= link_to t('.terms_of_service'), "#", class: "text-secondary font-bold underline hover:opacity-80" %>と<%= link_to t('.privacy_policy'), "#", class: "text-secondary font-bold underline hover:opacity-80" %><br>
-          <%= t('.terms_agreement') %>
-        </div>
-<%
-=end
-%>
 
         <%# 登録ボタン %>
         <div class="mb-10">
-          <%= f.submit t('.sign_up'), class: "btn-main", data: { turbo: false } %>
+          <%= f.submit t('.sign_up'), class: "btn-main" %>
         </div>
       <% end %>
 
@@ -66,6 +54,6 @@
       <div class="text-center">
         <%= link_to t('.sign_in'), new_session_path(resource_name), class: "inline-block btn-sub" %>
       </div>
-    <%# </div> %>
+    </div>
   </main>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,49 +19,11 @@
               class: "form-text-field" %>
         </div>
 
-<%
-=begin
-%>
-        <%# パスワードを忘れた方 %>
-        <div class="mb-4 text-sm text-text">
-          <%= t('.forgot_password') %><%= link_to t('.forgot_password_link'), new_password_path(resource_name), class: "text-secondary font-bold underline hover:opacity-80" %>
-        </div>
-
-        <%# ログイン状態を保持 %>
-        <% if devise_mapping.rememberable? %>
-          <div class="mb-8 flex items-center">
-            <%= f.check_box :remember_me, class: "w-4 h-4 text-text border-gray-300 rounded focus:ring-primary" %>
-            <%= f.label :remember_me, t('.remember_me'), class: "ml-2 text-sm text-text" %>
-          </div>
-        <% end %>
-<%
-=end
-%>
-
         <%# ログインボタン %>
         <div class="mt-14 mb-12">
           <%= f.submit t('.sign_in'), class: "btn-main" %>
         </div>
       <% end %>
-
-<%
-=begin
-%>
-      <%# Googleログインボタン %>
-      <div class="mb-6">
-        <%= link_to "#", class: "w-full flex items-center justify-center gap-3 btn-sub" do %>
-          <svg class="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-          </svg>
-          <%= t('.google_login') %>
-        <% end %>
-      </div>
-<%
-=end
-%>
 
       <%# 新規登録リンク %>
       <div class="text-center text-text">


### PR DESCRIPTION
## 概要
ログイン・新規登録ページのdiv閉じタグが足りていなかったのでHTML構造の見直し。
- Close #251
- 関連issue #250 ：turboは関係なさそうだったので戻す

## 実装理由
ログイン・新規登録ページのdiv閉じタグが足りていなかった（コメント追加時に構造が壊れた可能性）ため、ページをリロードしないとボタンが反応しなかった。

## 作業内容
- コメントアウトしたフォーム部分をdocsに切り出し
- HTML構造の見直し

## 作業結果
- ボタンが反応するようになる。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
