### PR TITLE
【add】devcontainerのファイルを作成だけしたのでgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 /public/image
 /docs
 /.vscode
+.devcontainer


### PR DESCRIPTION
## 概要
devcontainerのファイルを作成だけしたのでgitignoreに追加する。
- Close #100 

## 実装理由
devcontainerの準備のため。

## 作業内容
- .devcontainerフォルダとdevcontainer.jsonを作成
- gitignoreに.devcontainerを追加

## 作業結果
- うまく動作しなかったので、いったんファイルだけ残しておく。

## 課題・備考
- devcontainerをうまく動作させたい。
