### PR TITLE
【fix】本リリースに向けてdbdiagramの修正

### DIFF
--- a/dbdiagram
+++ b/dbdiagram
@@ -230,43 +230,50 @@ Table comments {
 
 }
 
-Table personal_packing_items {
+Table item_lists {
   id int [pk, increment]
-  user_id int [not null, ref: > users.id, note: "ユーザーID"]
-  name varchar(50) [not null, note: "持ち物名"]
-  is_checked boolean [not null, default: false, note: "チェック済みか"]
-  category varchar(20) [note: "カテゴリ（自由入力）"]
-  display_order int [not null, default: 0]
+  listable_type varchar [not null, note: "'User' or 'Schedule'"]
+  listable_id int [not null, note: "user_id or schedule_id"]
+  name varchar(100) [note: "リスト名"]
   created_at timestamp [not null]
   updated_at timestamp [not null]
 
   Indexes {
-    (user_id, display_order) [name: "index_personal_packing_on_user_and_order"]
+    (listable_type, listable_id) [unique, name: "index_item_lists_on_listable"]
   }
 
   Note: '''
-  個人用の持ち物チェックリスト。
-  '''
+  持ち物リスト（ポリモーフィック）
+  - User has_one :item_list (listable_type='User') ... ユーザーの永続的なマスターリスト
+  - Schedule has_one :item_list (listable_type='Schedule') ... しおりごとの持ち物リスト
 
+  リストの種類の判別:
+  - マスターリスト: listable_type == 'User'
+  - 個人しおり: listable_type == 'Schedule' && schedule.schedulable_type == 'User'
+  - グループしおり: listable_type == 'Schedule' && schedule.schedulable_type == 'Group'
+
+  マスターリストからしおり用リストへのコピーが可能。
+  '''
 }
 
-Table group_packing_items {
+Table items {
   id int [pk, increment]
-  group_id int [not null, ref: > groups.id, note: "所属グループ"]
-  name varchar(50) [not null, note: "持ち物名"]
-  is_checked boolean [not null, default: false, note: "チェック済みか"]
-  category varchar(20) [note: "カテゴリ"]
-  display_order int [not null, default: 0]
+  item_list_id int [not null, ref: > item_lists.id, note: "所属リスト"]
+  name varchar(100) [not null, note: "持ち物名"]
+  checked boolean [not null, default: false, note: "準備済みか"]
+  position int [note: "並び順（acts_as_listで管理）"]
   created_at timestamp [not null]
   updated_at timestamp [not null]
 
   Indexes {
-    (group_id, display_order) [name: "index_group_packing_on_group_and_order"]
+    item_list_id [name: "index_items_on_item_list_id"]
+    (item_list_id, position) [name: "index_items_on_list_and_position"]
   }
 
   Note: '''
-  グループ共有の持ち物リスト。
-  グループに紐づく。
+  個別の持ち物アイテム。
+  - acts_as_listでpositionを管理（スコープ: item_list_id）
+  - checked: 準備完了フラグ（Ajax更新）
   '''
 }
 
@@ -290,69 +297,50 @@ Table likes {
   '''
 }
 
-Table areas {
-  id int [pk, increment]
-  card_id int [not null, ref: > cards.id, note: "所属カード"]
-  name varchar(30) [not null, note: "エリア名（札幌、函館、小樽など）"]
-  display_order int [not null, default: 0, note: "表示順"]
-  created_at timestamp [not null]
-  updated_at timestamp [not null]
-
-  Indexes {
-    (card_id, display_order) [name: "index_areas_on_card_and_order"]
-  }
-
-  Note: '''
-  カード内でスポットをエリアごとに分類。
-  例: 北海道カード → 札幌 / 函館 / 小樽
-  spots.area_idで紐づける。
-  '''
-
-}
-
 Table expenses {
   id int [pk, increment]
   group_id int [not null, ref: > groups.id]
   paid_by_membership_id int [not null, ref: > group_memberships.id, note: "立て替えた人"]
-
   name varchar(100) [not null, note: "項目名（ホテル代、交通費等）"]
-  amount decimal(10, 2) [not null, note: "支払額"]
+  amount decimal(10, 1) [not null, note: "支払額（小数第一位まで、第二位で切り捨て）"]
+  memo text [note: "支出に関する自由記述メモ"]
   paid_at date
-
   created_at timestamp [not null]
   updated_at timestamp [not null]
 
   Indexes {
     group_id [name: "index_expenses_on_group_id"]
   }
+
+  Note: '''
+  グループの支出を記録。
+  金額は小数第一位まで保存し、均等割り時の端数を正確に計算。
+  メモフィールドで支出の詳細や理由を記録可能。
+
+  例：
+  支出: 10,000円、参加者: 3人
+  → 各自の負担: 3,333.3円（小数第一位まで表示）
+  メモ: 「タクシー代。C,Dは別行動のため不参加」
+  '''
 }
 
 Table expense_participants {
   id int [pk, increment]
   expense_id int [not null, ref: > expenses.id]
-  group_membership_id int [not null, ref: > group_memberships.id, note: "割り勘対象者"]
-  amount decimal(10, 2) [not null, note: "この人の負担額"]
-
-  created_at timestamp [not null]
-  updated_at timestamp [not null]
-}
-
-Table settlements {
-  id int [pk, increment]
-  group_id int [not null, ref: > groups.id]
-
-  from_membership_id int [not null, ref: > group_memberships.id, note: "支払う人"]
-  to_membership_id int [not null, ref: > group_memberships.id, note: "受け取る人"]
-  amount decimal(10, 2) [not null, note: "精算額"]
-
-  is_settled boolean [default: false, note: "精算完了か"]
-  settled_at timestamp [note: "精算完了日時"]
-
+  group_membership_id int [not null, ref: > group_memberships.id, note: "この支出の参加者"]
   created_at timestamp [not null]
   updated_at timestamp [not null]
 
   Indexes {
-    (group_id, from_membership_id, to_membership_id) [unique, name: "index_settlements_unique"]
+    (expense_id, group_membership_id) [unique, name: "index_expense_participants_unique"]
+    expense_id [name: "index_expense_participants_on_expense_id"]
+    group_membership_id [name: "index_expense_participants_on_membership_id"]
   }
 
+  Note: '''
+  支出の参加者を記録。
+  各支出に対して、誰が負担するかを管理。
+  支出金額を参加者数で均等割りして各自の負担額を計算する。
+  デフォルトは全メンバーが参加、必要に応じて除外可能。
+  '''
 }


### PR DESCRIPTION
## 概要
本リリースに向けてdbdiagramを修正する。

## 実装理由
本リリースに向けて設計を見直したため。

## 作業内容
1. もちものテーブルの修正（item_listsテーブルとitemsテーブルで管理する）
2. 精算テーブルの修正（settlementsテーブルを削除）
3. areasテーブルの削除

## 作業結果
データベースの設計が修正される。

## 課題・備考
なし
