### PR TITLE
【add】独自ドメインの設定追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # 独自ドメインの追加
+  config.hosts << "rakuci.com"      # 独自ドメイン
+  config.hosts << "www.rakuci.com"  # サブドメイン
 end


### PR DESCRIPTION
## 概要
独自ドメインの設定をproduction.rbに追加
- Close #64 

## 実装理由
独自ドメインを取得したため

## 作業内容
1. production.rbにドメインを追加

## 作業結果
- 取得した独自ドメインでアクセスできる（render、お名前ドットコム上でも設定は必要）

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
