### PR TITLE
【add】独自ドメインの一覧にonrenderのサブドメインを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,4 +105,5 @@ Rails.application.configure do
   # 独自ドメインの追加
   config.hosts << "rakuci.com"      # 独自ドメイン
   config.hosts << "www.rakuci.com"  # サブドメイン
+  config.hosts << "rakuci.onrender.com"     # Render.comのデフォルトドメイン
 end


### PR DESCRIPTION
## 概要
独自ドメインの一覧にonrenderのサブドメインを追加する
- Close #64

## 実装理由
設定ファイルにonrederの独自ドメインを追加し忘れていたため

## 作業内容
1. production,rbに、rakuci.onrender.comを追加

## 作業結果
- rakuci.onrender.comでもアクセスできるようになる。

## 課題・備考
なし
