### PR TITLE
【fix】スマホでGooglemapに遷移できない

### DIFF
--- a/app/views/spots/_show_content.html.erb
+++ b/app/views/spots/_show_content.html.erb
@@ -7,7 +7,7 @@
       <div class="flex items-center gap-2 mb-8">
         <h1 class="text-2xl font-bold text-text"><%= @spot.name %></h1>
         <% if @spot.google_place_id.present? %>
-          <%= link_to "https://maps.google.com/maps?q=place_id:#{@spot.google_place_id}", target: "_blank", rel: "noopener noreferrer", class: "hover:opacity-70 transition" do %>
+          <%= link_to "https://www.google.com/maps/search/?api=1&query=7-Elevan&query_place_id=#{@spot.google_place_id}", target: "_blank", rel: "noopener noreferrer", class: "hover:opacity-70 transition" do %>
             <%= render "shared/icon/map_icon_google" %>
           <% end %>
         <% end %>


### PR DESCRIPTION
## 概要
スマホでGooglemapに遷移できない。
- Close #255 

## 実装理由
スポット詳細に設置しているGooglemapへのリンクから、スポットの場所に遷移できない。

## 作業内容
1. 設定しているgooglemapのURLを修正

## 作業結果
- パソコン・スマホからスポットのマップへアクセスできる。

## 未実施項目
issueはすべて実施。

## 課題・備考
- [google maps Platform公式](https://developers.google.com/maps/architecture/maps-url?hl=ja)の、シナリオ3の方法2を参考にURLを設定する。
