### PR TITLE
【add】Googleアナリティクスの実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- Google tag (gtag.js) -->
+    <% if Rails.env.production? %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_ID'] %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '<%= ENV['GA_TRACKING_ID'] %>');
+      </script>
+    <% end %>
+
     <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%# webアプリがモバイル上でフルスクリーンで動作することを示すメタタグ（旧） %>


### PR DESCRIPTION
## 概要
Googleアナリティクスを実装する。
- Close #328 

## 実装理由
アプリのユーザー動向を集計するため。

## 作業内容
1. application.html.erbのheadタグに、Googleから発行されるタグを追加
2. トラッキングタグはrenderの環境変数に追加

## 作業結果
- GA4の計測が開始される

## 未実施項目
issueはすべて実施。

## 課題・備考
- 開発環境では計測しないように、googleタグは本番環境のみを条件に指定。
