### PR TITLE
【fix】グループのメンバー削除ボタンを管理者しか表示されないように修正

### DIFF
--- a/app/views/groups/_details.html.erb
+++ b/app/views/groups/_details.html.erb
@@ -77,8 +77,11 @@
       <% @group.group_memberships.each do |membership| %>
         <div class="flex items-center justify-between p-2 hover:bg-gray-50 rounded">
           <span class="text-sm text-text"><%= membership.group_nickname %></span>
-          <%= button_to group_group_membership_path(@group, membership), method: :delete, form_class: "inline", class: "btn-danger px-3 py-1 text-sm", data: { turbo_confirm: "#{membership.group_nickname}#{t('groups.details.delete_confirm')}" } do %>
-            <%= t('groups.details.delete_button') %>
+          <%# オーナーのみが削除ボタンを表示、かつオーナー本人は削除できない %>
+          <% if current_user&.id == @group.created_by_user_id && !membership.owner? %>
+            <%= button_to group_group_membership_path(@group, membership), method: :delete, form_class: "inline", class: "btn-danger px-3 py-1 text-sm", data: { turbo_confirm: "#{membership.group_nickname}#{t('groups.details.delete_confirm')}" } do %>
+              <%= t('groups.details.delete_button') %>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/groups/memberships/destroy.turbo_stream.erb
+++ b/app/views/groups/memberships/destroy.turbo_stream.erb
@@ -7,8 +7,11 @@
     <% @group.group_memberships.each do |membership| %>
       <div class="flex items-center justify-between p-2 hover:bg-gray-50 rounded">
         <span class="text-sm text-text"><%= membership.group_nickname %></span>
-        <%= button_to group_group_membership_path(@group, membership), method: :delete, form_class: "inline", class: "btn-sub px-3 py-1 text-sm", data: { turbo_confirm: "#{membership.group_nickname}を削除しますか？" } do %>
-          削除
+        <%# オーナーのみが削除ボタンを表示、かつオーナー本人は削除できない %>
+        <% if current_user&.id == @group.created_by_user_id && !membership.owner? %>
+          <%= button_to group_group_membership_path(@group, membership), method: :delete, form_class: "inline", class: "btn-danger px-3 py-1 text-sm", data: { turbo_confirm: "#{membership.group_nickname}を削除しますか？" } do %>
+            削除
+          <% end %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
## 概要
グループのメンバー削除ボタンを管理者しか表示されないように修正する。
- Close #335 

## 実装理由
グループからメンバーを削除するのは管理者にまかせて、他のユーザーには削除ボタンを表示しないようにするため。

## 作業内容
- /groups/memberships/_details.html.erbを修正
- /groups/memberships/destroy.turbo_stream.erbを修正

## 作業結果
- 管理者にしか削除ボタンが表示されない。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
