### PR TITLE
【fix】スポットモデルにカテゴリのバリデーション追加（抜けもれ）

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -32,6 +32,9 @@ class Spot < ApplicationRecord
   belongs_to :category
 
   validates :name, presence: true, length: { maximum: 50 }
+  # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo（エラーメッセージ表示のためのコメント）
+  validates :category_id, presence: true
+  # rubocop:enable Rails/RedundantPresenceValidationOnBelongsTo
   validates :phone_number, length: { maximum: 20 }, allow_blank: true
   validates :website_url, format: { with: URI::DEFAULT_PARSER.make_regexp([ "http", "https" ]) }, allow_blank: true
   validates :google_place_id, uniqueness: { scope: :card_id }, allow_blank: true


### PR DESCRIPTION
## 概要
スポットモデルにカテゴリのバリデーション追加（抜けもれ）

## 実装理由
リリース前の確認で実装したはずが抜け漏れていたので追加修正
（categoryは関連付けで必須になっているので、バリデーションでpresence: trueが冗長表現としてlinterで削除されていた）

## 作業内容
1. spotモデルにカテゴリを必須のバリデーションを追加して、カードにスポットを追加するときにカテゴリを必須にする。（メッセージ表記はすでに実装済み）

## 作業結果
- 空でスポットを追加しようとすると、エラーでメッセージが表示される

## 課題・備考
なし
