### PR TITLE
【fix】持ち物リスト空の時に作成するメソッドがprivateになっていたのでメソッドではく直接作成に修正

### DIFF
--- a/app/controllers/users/item_lists_controller.rb
+++ b/app/controllers/users/item_lists_controller.rb
@@ -18,9 +18,9 @@ class Users::ItemListsController < ApplicationController
 
   def set_item_list
     @item_list = if params[:schedule_id].present?
-      @schedule.item_list || @schedule.create_item_list
+      @schedule.item_list || ItemList.create(listable: @schedule)
     else
-      current_user.item_list || current_user.create_item_list
+      current_user.item_list || ItemList.create(listable: current_user)
     end
   end
 


### PR DESCRIPTION
## 概要
持ち物リスト空の時に作成するメソッドを、直接作成するコードに修正する


## 実装理由
持ち物リスト空の時に作成するメソッドがprivateになっていたため。

## 作業内容
1. メソッドの参照ではなく、createで作成するように修正

## 作業結果
- 持ち物りすとが空の時に作成される

## 課題・備考

