### PR TITLE
【fix】トップページのpadding_topの幅を調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -32,7 +32,7 @@ test {
 body {
   font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
   /* ヘッダーで隠れないようにヘッダー分をあけておく */
-  padding-top: 71px;
+  padding-top: 65px;
 }
 
 


### PR DESCRIPTION
## 概要
トップページのpadding_topの幅を調整する。

## 実装理由
トップページのヘッダーとbodyの境界に白い背景が見えているため。

## 作業内容
1. CSSのpadding_topを調整する。

## 作業結果
- トップページのヘッダーとの境界が修正される。

## 課題・備考
なし
