### PR TITLE
【fix】精算ページのチェックボックスの範囲を修正する

### DIFF
--- a/app/views/groups/expenses/index.html.erb
+++ b/app/views/groups/expenses/index.html.erb
@@ -35,10 +35,10 @@
           </div>
           <div class="space-y-2">
             <% @group.group_memberships.each do |membership| %>
-              <label class="flex items-center gap-2">
-                <%= check_box_tag "expense[participant_ids][]", membership.id, true, { class: "form-checkbox" } %>
-                <span class="text-text"><%= membership.nickname %></span>
-              </label>
+              <div class="flex items-center gap-2">
+                <%= check_box_tag "expense[participant_ids][]", membership.id, true, { id: "member_#{membership.id}", class: "form-checkbox" } %>
+                <%= label_tag "member_#{membership.id}", membership.nickname, class: "text-text cursor-pointer" %>
+              </div>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## 概要
精算ページのチェックボックスの範囲を修正する
- Close #395 

## 実装理由
ボックスと名前表示範囲以外のところでも、チェックボックスのオンオフが切り替わってしまうため。

## 作業内容
1. label表示の範囲を狭くするためにビューを修正

## 作業結果
- オンオフの切り替えが、ボックスと名前あたりに狭められる。

## 未実施項目
issueはすべて実施。

## 課題・備考
なし
