### PR TITLE
【add】dependabotを設定する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,49 @@
-# version: 2
-# updates:
-# - package-ecosystem: bundler
-#   directory: "/"
-#   schedule:
-#     interval: daily
-#   open-pull-requests-limit: 10
-# - package-ecosystem: github-actions
-#   directory: "/"
-#   schedule:
-#     interval: daily
-#   open-pull-requests-limit: 10
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      linting:
+        patterns:
+          - "rubocop*"
+          - "brakeman"
+      testing:
+        patterns:
+          - "rspec*"
+          - "factory_bot*"
+          - "faker"
+          - "capybara"
+          - "cuprite"
+          - "simplecov"
+      development:
+        patterns:
+          - "web-console"
+          - "better_errors"
+          - "binding_of_caller"
+          - "ruby-lsp"
+          - "annotate"
+          - "rack-mini-profiler"
+          - "bullet"
+          - "debug"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要
dependabotを設定する
- Close #480 

## 実装理由
dependabot.ymlを設定していなかったため。

## 作業内容
1. リポジトリからdependabotを有効化
2. dependabot.ymlを作成

## 作業結果
- dependabotが走る

## 未実施項目
issueはすべて実施

## 課題・備考
スケジュールにあわせて走るか要確認
